### PR TITLE
data/init.vim: cleanup leftovers from a previous stash conflict

### DIFF
--- a/data/init.nvim
+++ b/data/init.nvim
@@ -125,7 +125,6 @@ let g:syntastic_auto_loc_list = 0
 let g:syntastic_check_on_open = 1
 let g:syntastic_check_on_wq = 0
 
->>>>>>> Stashed changes
 let g:go_fmt_command = "goimports"
 
 nnoremap <silent> <Leader>ew :StripWhitespace<CR>


### PR DESCRIPTION
I was going through your dotfiles, very interesting stuff here :)
Came across this minor leftover (probably) from a previous stash conflict.

PS. Although I'm quite curious how neovim didn't report this to you :thinking: 